### PR TITLE
Replace references to files in Dropbox folder

### DIFF
--- a/html/files.html
+++ b/html/files.html
@@ -54,7 +54,7 @@
 
 										<div class="col-lg-12 margin-top">
 											<p class="title">Load .csv or spreadsheet</p>
-											<p>Copy and paste out of your spreadsheets, drag-and-drop to upload tabular data (e.g. .csv, .tab, .tsv), or enter a URL to a tabular data file to create a new Palladio project. <a target="_blank" href="http://hdlab.stanford.edu/palladio">Not sure how to structure your data?</a></p>
+											<p>Copy and paste out of your spreadsheets, drag-and-drop to upload tabular data (e.g. .csv, .tab, .tsv), or enter <a href="https://hdlab.stanford.edu/palladio/tutorials/publicdata/" target="_blank">a URL to a tabular data file</a> to create a new Palladio project. <a target="_blank" href="https://hdlab.stanford.edu/palladio/help/#2">Not sure how to structure your data?</a></p>
 											<textarea ui-codemirror="{ mode : 'text',  lineNumbers : true, lineWrapping: true, onDrop : onDrop }" placeholder="Paste your data or drop a file here" ng-model="text"></textarea>
 											<div class="alert alert-warning" ng-show="parseError">{{parseError}}</div>
 											<a class="btn btn-default" ng-click="parseExtendTable()" ng-disabled="!text">Load</a>

--- a/html/files.html
+++ b/html/files.html
@@ -54,7 +54,7 @@
 
 										<div class="col-lg-12 margin-top">
 											<p class="title">Load .csv or spreadsheet</p>
-											<p>Copy and paste out of your spreadsheets, drag-and-drop to upload tabular data (e.g. .csv, .tab, .tsv), or link to a file in a public Dropbox folder to create a new Palladio project. <a target="_blank" href="http://hdlab.stanford.edu/palladio">Not sure how to structure your data?</a></p>
+											<p>Copy and paste out of your spreadsheets, drag-and-drop to upload tabular data (e.g. .csv, .tab, .tsv), or enter a URL to a tabular data file to create a new Palladio project. <a target="_blank" href="http://hdlab.stanford.edu/palladio">Not sure how to structure your data?</a></p>
 											<textarea ui-codemirror="{ mode : 'text',  lineNumbers : true, lineWrapping: true, onDrop : onDrop }" placeholder="Paste your data or drop a file here" ng-model="text"></textarea>
 											<div class="alert alert-warning" ng-show="parseError">{{parseError}}</div>
 											<a class="btn btn-default" ng-click="parseExtendTable()" ng-disabled="!text">Load</a>

--- a/html/refine.html
+++ b/html/refine.html
@@ -14,7 +14,7 @@
 				<div class="row" data-ng-show="addingTable">
 
 					<div class="col-lg-12">
-						<p class="">Copy and paste out of your spreadsheets, drag-and-drop to upload tabular data (e.g. .csv, .tab, .tsv), or link to a file in a public Dropbox folder to add a new table to your Palladio project. <a target="_blank" href="http://hdlab.stanford.edu/lab-notebook/palladio/2014/11/18/palladio-faqs-0-8-0/#2">Not sure how to structure your data?</a></p>
+						<p class="">Copy and paste out of your spreadsheets, drag-and-drop to upload tabular data (e.g. .csv, .tab, .tsv), or link to a URL to a tabular data file to add a new table to your Palladio project. <a target="_blank" href="http://hdlab.stanford.edu/lab-notebook/palladio/2014/11/18/palladio-faqs-0-8-0/#2">Not sure how to structure your data?</a></p>
 						<textarea ui-refresh="selectedFieldMetadata" ui-codemirror="{ mode : 'text',  lineNumbers : true, lineWrapping: true, onDrop : onDrop }" placeholder="Paste your data or drop a file here" ng-model="text"></textarea>
 						<div class="alert alert-warning" ng-show="parseError">{{parseError}}</div>
 

--- a/html/refine.html
+++ b/html/refine.html
@@ -14,7 +14,7 @@
 				<div class="row" data-ng-show="addingTable">
 
 					<div class="col-lg-12">
-						<p class="">Copy and paste out of your spreadsheets, drag-and-drop to upload tabular data (e.g. .csv, .tab, .tsv), or link to a URL to a tabular data file to add a new table to your Palladio project. <a target="_blank" href="http://hdlab.stanford.edu/lab-notebook/palladio/2014/11/18/palladio-faqs-0-8-0/#2">Not sure how to structure your data?</a></p>
+						<p class="">Copy and paste out of your spreadsheets, drag-and-drop to upload tabular data (e.g. .csv, .tab, .tsv), or link to <a href="https://hdlab.stanford.edu/palladio/tutorials/publicdata/" target="_blank">a URL to a tabular data file</a> to add a new table to your Palladio project. <a target="_blank" href="https://hdlab.stanford.edu/palladio/help/#2">Not sure how to structure your data?</a></p>
 						<textarea ui-refresh="selectedFieldMetadata" ui-codemirror="{ mode : 'text',  lineNumbers : true, lineWrapping: true, onDrop : onDrop }" placeholder="Paste your data or drop a file here" ng-model="text"></textarea>
 						<div class="alert alert-warning" ng-show="parseError">{{parseError}}</div>
 

--- a/html/start.html
+++ b/html/start.html
@@ -28,7 +28,7 @@
 
 		<div class="margin-bottom col-lg-3 col-lg-offset-1 col-md-4 col-sm-6">
 			<p class="big">Create or Open Palladio projects</p>
-			<p class="big text-muted">Copy and paste out of your spreadsheets, drag-and-drop to upload tabular data (e.g. .csv, .tab, .tsv), or link to a file in a public Dropbox folder to create a new Palladio project.</p>
+			<p class="big text-muted">Copy and paste out of your spreadsheets, drag-and-drop to upload tabular data (e.g. .csv, .tab, .tsv), or link to a URL to a tabular data file to create a new Palladio project.</p>
 		</div>
 
 		<div class="col-lg-7 col-md-8 col-sm-6">


### PR DESCRIPTION
This (perhaps naively) fixes #7 by replacing references to public Dropbox folders with 'URL to a tabular data file'.